### PR TITLE
Support libraries like bem-cn that expect `className`s to be converted to string

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ bill
 =======
 
 Sort of like [Sizzle](https://github.com/jquery/sizzle/tree/master#sizzle) for React, `bill` is
-A set of tools for matching React Element and Component trees against CSS selectors. `bill` is meant to be a
+a set of tools for matching React Element and Component trees against CSS selectors. `bill` is meant to be a
 substrate library for building more interesting and user friendly testing utilities. It probably shouldn't
 be used as a standalone tool.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bill",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "css selectors for React Elements",
   "main": "lib/index.js",
   "scripts": {

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -106,7 +106,7 @@ export function create(options = {}) {
     if (rule.classNames)
       fns.push(
         failText(({ element: { props } }) => {
-          let className = props && props.className
+          let className = props && '' + props.className
           return rule.classNames.every(clsName =>
             className && className.indexOf(clsName) !== -1)
         })

--- a/test/compiler.js
+++ b/test/compiler.js
@@ -29,6 +29,19 @@ describe('create compiler', ()=> {
     }).should.equal(true)
   })
 
+  it('should coerce className helpers to string', ()=> {
+    let result = compile('a.foo')
+    let bemHelper = () => {}
+    bemHelper.toString = () => 'foo'
+
+    result({
+      type: 'a',
+      props: {
+        className: bemHelper
+      }
+    }).should.equal(true)
+  })
+
   it('should fail when not a match', ()=>{
     let result = compile('a.foo')
 


### PR DESCRIPTION
We're using the [bem-cn](https://github.com/albburtsev/bem-cn) library which will return objects (functions actually) that expect to be converted into strings from React. Those objects look like:

```
{ [Function: bound callableInstance]
  toString: [Function: bound toString],
  split: [Function: bound split],
  mix: [Function: bound mix],
  state: [Function: bound state] }
```

This doesn't play nicely with bill b/c it expects raw strings, so simply adding `.toString()` solved this issue.
