### PR TITLE
Fix: Error: Cannot find module 'semver'

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "mocha": "^2.3.3",
     "mt-changelog": "^0.6.2",
     "react": "^0.13.0 || ^0.14.0",
+    "semver": "^5.1.0",
     "sinon": "^1.17.1",
     "sinon-chai": "^2.8.0",
     "trim-package-json": "^1.0.0",


### PR DESCRIPTION
Using:
node v4.3.2
npm  v2.14.12

```
node
> require('./lib/compat')
Error: Cannot find module 'semver'
    at Function.Module._resolveFilename (module.js:325:15)
    at Function.Module._load (module.js:276:25)
    at Module.require (module.js:353:17)
    at require (internal/module.js:12:17)
    at Object.<anonymous> (/home/brad/development/github.com/jquense/bill/lib/compat.js:12:15)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Module.require (module.js:353:17)
```
